### PR TITLE
Add @EnableSmartCosmosMonitoring

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,0 +1,15 @@
+= SMART COSMOS DevKit User Details Service Release Notes
+
+== UNRELEASED
+
+=== New Features
+
+* OBJECTS-980 Add Prometheus-compatible `/metrics` endpoint
+
+=== Bugfixes & Improvements
+
+None.
+
+== Release 3.0.0 (August 12, 2016)
+
+Initial release.

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,13 @@
     267 Cane Creek Rd, Fletcher, NC, 28732, USA
     All Rights Reserved.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>net.smartcosmos</groupId>
         <artifactId>smartcosmos-framework-parent</artifactId>
-        <version>3.0.0</version>
+        <version>3.0.1-SNAPSHOT</version>
         <relativePath></relativePath>
     </parent>
     <artifactId>smartcosmos-user-details-devkit</artifactId>
@@ -28,7 +29,6 @@
             <dependency>
                 <groupId>org.mapstruct</groupId>
                 <artifactId>mapstruct</artifactId>
-                <version>1.0.0.Final</version>
             </dependency>
             <dependency>
                 <groupId>net.smartcosmos</groupId>
@@ -58,6 +58,10 @@
         <dependency>
             <groupId>net.smartcosmos</groupId>
             <artifactId>smartcosmos-framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.smartcosmos</groupId>
+            <artifactId>smartcosmos-framework-monitoring</artifactId>
         </dependency>
         <dependency>
             <groupId>net.smartcosmos</groupId>

--- a/src/main/java/net/smartcosmos/cluster/userdetails/DevKitUserDetailsService.java
+++ b/src/main/java/net/smartcosmos/cluster/userdetails/DevKitUserDetailsService.java
@@ -15,6 +15,7 @@ import net.smartcosmos.cluster.userdetails.config.ServiceUserAccessSecurityConfi
 
 @EnableSmartCosmosExtension
 @EnableSmartCosmosEvents
+@EnableSmartCosmosMonitoring
 @Import(ServiceUserAccessSecurityConfiguration.class)
 @Slf4j
 public class DevKitUserDetailsService extends WebMvcAutoConfiguration.WebMvcAutoConfigurationAdapter {

--- a/src/main/java/net/smartcosmos/cluster/userdetails/DevKitUserDetailsService.java
+++ b/src/main/java/net/smartcosmos/cluster/userdetails/DevKitUserDetailsService.java
@@ -11,6 +11,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 import net.smartcosmos.annotation.EnableSmartCosmosEvents;
 import net.smartcosmos.annotation.EnableSmartCosmosExtension;
+import net.smartcosmos.annotation.EnableSmartCosmosMonitoring;
 import net.smartcosmos.cluster.userdetails.config.ServiceUserAccessSecurityConfiguration;
 
 @EnableSmartCosmosExtension


### PR DESCRIPTION
### What changes were proposed in this pull request?

adds the `@EnableSmartCosmosMonitoring` annotation which adds a new `/metrics` endpoint for Prometheus 

### How is this patch documented?

- Code
- Javadoc in Framework

### How was this patch tested?

manually

#### Depends On

https://github.com/SMARTRACTECHNOLOGY/smartcosmos-framework/pull/196