### PR TITLE
Bugfix/objects 1034

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -10,6 +10,7 @@
 === Bugfixes & Improvements
 
 * OBJECTS-1027 User Details Services return 401 Unauthorized for both wrong Basic Auth service credentials and miss for actual user credentials
+* OBJECTS-1034 Invalid User Details Request results in Internal Server Error response from the Auth server
 
 == Release 3.0.0 (August 12, 2016)
 

--- a/src/main/java/net/smartcosmos/cluster/userdetails/resource/AuthenticationResource.java
+++ b/src/main/java/net/smartcosmos/cluster/userdetails/resource/AuthenticationResource.java
@@ -6,6 +6,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -15,6 +17,8 @@ import net.smartcosmos.cluster.userdetails.domain.AuthenticateUserRequest;
 import net.smartcosmos.cluster.userdetails.service.AuthenticateUserService;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
+
+import static net.smartcosmos.cluster.userdetails.util.ResponseEntityFactory.invalidUsernameOrPassword;
 
 @Slf4j
 @SmartCosmosRdao
@@ -35,5 +39,11 @@ public class AuthenticationResource {
     public ResponseEntity<?> authenticate(@RequestBody @Valid AuthenticateUserRequest requestBody) {
 
         return service.authenticateUser(requestBody);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<?> errorResponse() {
+
+        return invalidUsernameOrPassword();
     }
 }

--- a/src/main/java/net/smartcosmos/cluster/userdetails/service/AuthenticateUserServiceDevKit.java
+++ b/src/main/java/net/smartcosmos/cluster/userdetails/service/AuthenticateUserServiceDevKit.java
@@ -8,10 +8,11 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.stereotype.Service;
 
 import net.smartcosmos.cluster.userdetails.domain.AuthenticateUserRequest;
-import net.smartcosmos.cluster.userdetails.domain.MessageResponse;
 import net.smartcosmos.cluster.userdetails.domain.UserDetails;
 
-import static net.smartcosmos.cluster.userdetails.domain.MessageResponse.CODE_ERROR;
+import static net.smartcosmos.cluster.userdetails.util.ResponseEntityFactory.invalidDataReturned;
+import static net.smartcosmos.cluster.userdetails.util.ResponseEntityFactory.invalidUsernameOrPassword;
+import static net.smartcosmos.cluster.userdetails.util.ResponseEntityFactory.success;
 
 /**
  * Default implementation of the user authentication service.
@@ -36,16 +37,13 @@ public class AuthenticateUserServiceDevKit implements AuthenticateUserService {
 
             if (userDetailsService.isValid(userDetails)) {
                 log.info("Validation of authentication response for user {} : valid", request.getName());
-                return ResponseEntity.ok(userDetails);
+                return success(userDetails);
             }
             log.info("Validation of authentication response for user {} : invalid", request.getName());
-            return ResponseEntity.badRequest()
-                .body(new MessageResponse(CODE_ERROR, "Invalid data returned"));
+            return invalidDataReturned();
         } catch (AuthenticationException e) {
             log.info("Authenticating user {} failed. Request was {}", request.getName(), request);
-            MessageResponse messageResponse = new MessageResponse(CODE_ERROR, e.getMessage());
-            return ResponseEntity.badRequest()
-                .body(messageResponse);
+            return invalidUsernameOrPassword();
         }
     }
 }

--- a/src/main/java/net/smartcosmos/cluster/userdetails/util/ResponseEntityFactory.java
+++ b/src/main/java/net/smartcosmos/cluster/userdetails/util/ResponseEntityFactory.java
@@ -1,0 +1,67 @@
+package net.smartcosmos.cluster.userdetails.util;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+import net.smartcosmos.cluster.userdetails.domain.MessageResponse;
+import net.smartcosmos.cluster.userdetails.domain.UserDetails;
+
+import static net.smartcosmos.cluster.userdetails.domain.MessageResponse.CODE_ERROR;
+
+/**
+ * Utility class for Response Entity creation.
+ */
+public class ResponseEntityFactory {
+
+    /**
+     * Success response for user details.
+     *
+     * @param userDetails the user details
+     * @return the response entity
+     */
+    public static ResponseEntity<?> success(UserDetails userDetails) {
+
+        return ResponseEntity.ok(userDetails);
+    }
+
+    /**
+     * Bad Request error response for invalid user credentials.
+     * <pre>{ "code": 1, "message": "Invalid username or password" }</pre>
+     *
+     * @return the response entity
+     */
+    public static ResponseEntity<?> invalidUsernameOrPassword() {
+
+        return ResponseEntity.badRequest()
+            .body(new MessageResponse(CODE_ERROR, "Invalid username or password"));
+    }
+
+    /**
+     * Internal Server Error response for invalid data retrieved from the user details provider.
+     * <pre>{ "code": 1, "message": "Invalid data returned" }</pre>
+     *
+     * @return the response entity
+     */
+    public static ResponseEntity<?> invalidDataReturned() {
+
+        return ResponseEntity.badRequest()
+            .body(new MessageResponse(CODE_ERROR, "Invalid data returned"));
+    }
+
+    /**
+     * General error response.
+     * <pre>{ "code": code, "message": message }</pre>
+     *
+     * @param httpStatus the HTTP status code
+     * @param code the error code
+     * @param message the error message
+     * @return the response entity
+     */
+    public static ResponseEntity<?> errorResponse(HttpStatus httpStatus, Integer code, String message) {
+
+        return ResponseEntity.status(httpStatus)
+            .contentType(MediaType.APPLICATION_JSON_UTF8)
+            .body(new MessageResponse(code, message));
+    }
+}

--- a/src/test/java/net/smartcosmos/cluster/userdetails/resource/AuthenticationResourceTest.java
+++ b/src/test/java/net/smartcosmos/cluster/userdetails/resource/AuthenticationResourceTest.java
@@ -1,6 +1,7 @@
 package net.smartcosmos.cluster.userdetails.resource;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 
 import org.junit.*;
@@ -46,6 +47,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import static net.smartcosmos.cluster.userdetails.domain.MessageResponse.CODE_ERROR;
 import static net.smartcosmos.test.util.ResourceTestUtil.basicAuth;
 
 @WebAppConfiguration
@@ -190,9 +192,115 @@ public class AuthenticationResourceTest {
                 .content(json(request))
                 .contentType(APPLICATION_JSON_UTF8))
             .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code", is(CODE_ERROR)))
+            .andExpect(jsonPath("$.message").isString())
             .andReturn();
 
         verifyZeroInteractions(authenticationService);
+    }
+
+    @Test
+    public void thatMissingUsernameReturnsBadRequest() throws Exception {
+
+        final String usernameUnderTest = null;
+        final String passwordUnderTest = "hotpassword";
+
+        AuthenticateUserRequest request = AuthenticateUserRequest.builder()
+            .authorities(new ArrayList<>())
+            .authenticated(false)
+            .principal(usernameUnderTest)
+            .credentials(passwordUnderTest)
+            .name(usernameUnderTest)
+            .build();
+
+        MvcResult mvcResult = this.mockMvc.perform(
+            post("/authenticate")
+                .header(HttpHeaders.AUTHORIZATION, basicAuth("smartcosmostestclient", "testPasswordPleaseIgnore"))
+                .content(this.json(request))
+                .contentType(APPLICATION_JSON_UTF8))
+            .andExpect(status().isBadRequest())
+            .andExpect(content().contentType(APPLICATION_JSON_UTF8))
+            .andExpect(jsonPath("$.code", is(CODE_ERROR)))
+            .andExpect(jsonPath("$.message").isString())
+            .andReturn();
+    }
+
+    @Test
+    public void thatEmptyUsernameReturnsBadRequest() throws Exception {
+
+        final String usernameUnderTest = "";
+        final String passwordUnderTest = "hotpassword";
+
+        AuthenticateUserRequest request = AuthenticateUserRequest.builder()
+            .authorities(new ArrayList<>())
+            .authenticated(false)
+            .principal(usernameUnderTest)
+            .credentials(passwordUnderTest)
+            .name(usernameUnderTest)
+            .build();
+
+        MvcResult mvcResult = this.mockMvc.perform(
+            post("/authenticate")
+                .header(HttpHeaders.AUTHORIZATION, basicAuth("smartcosmostestclient", "testPasswordPleaseIgnore"))
+                .content(this.json(request))
+                .contentType(APPLICATION_JSON_UTF8))
+            .andExpect(status().isBadRequest())
+            .andExpect(content().contentType(APPLICATION_JSON_UTF8))
+            .andExpect(jsonPath("$.code", is(CODE_ERROR)))
+            .andExpect(jsonPath("$.message").isString())
+            .andReturn();
+    }
+
+    @Test
+    public void thatMissingPasswordReturnsBadRequest() throws Exception {
+
+        final String usernameUnderTest = "jules";
+        final String passwordUnderTest = null;
+
+        AuthenticateUserRequest request = AuthenticateUserRequest.builder()
+            .authorities(new ArrayList<>())
+            .authenticated(false)
+            .principal(usernameUnderTest)
+            .credentials(passwordUnderTest)
+            .name(usernameUnderTest)
+            .build();
+
+        MvcResult mvcResult = this.mockMvc.perform(
+            post("/authenticate")
+                .header(HttpHeaders.AUTHORIZATION, basicAuth("smartcosmostestclient", "testPasswordPleaseIgnore"))
+                .content(this.json(request))
+                .contentType(APPLICATION_JSON_UTF8))
+            .andExpect(status().isBadRequest())
+            .andExpect(content().contentType(APPLICATION_JSON_UTF8))
+            .andExpect(jsonPath("$.code", is(CODE_ERROR)))
+            .andExpect(jsonPath("$.message").isString())
+            .andReturn();
+    }
+
+    @Test
+    public void thatEmptyPasswordReturnsBadRequest() throws Exception {
+
+        final String usernameUnderTest = "jules";
+        final String passwordUnderTest = "";
+
+        AuthenticateUserRequest request = AuthenticateUserRequest.builder()
+            .authorities(new ArrayList<>())
+            .authenticated(false)
+            .principal(usernameUnderTest)
+            .credentials(passwordUnderTest)
+            .name(usernameUnderTest)
+            .build();
+
+        MvcResult mvcResult = this.mockMvc.perform(
+            post("/authenticate")
+                .header(HttpHeaders.AUTHORIZATION, basicAuth("smartcosmostestclient", "testPasswordPleaseIgnore"))
+                .content(this.json(request))
+                .contentType(APPLICATION_JSON_UTF8))
+            .andExpect(status().isBadRequest())
+            .andExpect(content().contentType(APPLICATION_JSON_UTF8))
+            .andExpect(jsonPath("$.code", is(CODE_ERROR)))
+            .andExpect(jsonPath("$.message").isString())
+            .andReturn();
     }
 
     // region Utilities


### PR DESCRIPTION
### What changes were proposed in this pull request?

Since we don't want to use the default handlers for invalid requests from Framework for user details services, a new `@ExceptionHandler` method catching `MethodArgumentNotValidException`, that are thrown by the `@Valid` annotation, is added.

In addition, responses are now created in a static `ResponseEntityFactory` for reusability purposes.

This will fix the bug that the auth-server returns a _500 Internal Error Message_ due to an empty response body for the _400 Bad Request_ response.
### How is this patch documented?

Code
### How was this patch tested?
- existing and additional unit tests
- manually in Postman
#### Depends On

Nothing
